### PR TITLE
Issue35 automatically save output

### DIFF
--- a/OpenPose_Colab.ipynb
+++ b/OpenPose_Colab.ipynb
@@ -602,7 +602,7 @@
         "                !zip -r $zip_file $output_dir\n",
         "                print('Created zip archive')\n",
         "\n",
-        "                if(items['create_model_video'].value):\n",
+        "                if(items['download_results'].value):\n",
         "                    files.download(zip_file)\n",
         "\n",
         "                # Update output dir if using the default\n",


### PR DESCRIPTION
Cleans up some stuff for #35 and changes how it works, as requested by Martin. The first part was already committed to master by mistake.